### PR TITLE
feat: implementação dos 3 relatórios no formato csv

### DIFF
--- a/Thunders.TechTest.ApiService/Application/ApplicationInitialization.cs
+++ b/Thunders.TechTest.ApiService/Application/ApplicationInitialization.cs
@@ -4,6 +4,8 @@ using Infrastructure.Domain.Mediator;
 using Thunders.TechTest.ApiService.CrossCutting.Extensions;
 using Thunders.TechTest.ApiService.CrossCutting.Mediator.Abstractions;
 using Thunders.TechTest.ApiService.CrossCutting.Validations;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+using Thunders.TechTest.ApiService.Services.Reports;
 using Thunders.TechTest.OutOfBox.Queues;
 
 namespace Thunders.TechTest.ApiService.Application;
@@ -22,6 +24,8 @@ internal static class ApplicationInitialization
         services.AddScoped<ValidationContext>();
 
         services.AddSingleton<IMessageSender, RebusMessageSender>();
+        services.AddTransient<IFileStorage, LocalFileStorage>();
+        services.AddScoped<IReportExecutorFactory, ReportExecutorFactory>();
 
         return services;
     }

--- a/Thunders.TechTest.ApiService/Data/Mappings/Tolls/TollPlazaConfiguration.cs
+++ b/Thunders.TechTest.ApiService/Data/Mappings/Tolls/TollPlazaConfiguration.cs
@@ -45,5 +45,9 @@ internal class TollPlazaConfiguration : IEntityTypeConfiguration<TollPlaza>
         builder.HasOne(_ => _.Concessionaire)
             .WithMany(_ => _.Plazas)
             .HasForeignKey("ConcessionaireId");
+
+        builder.HasMany(_ => _.Payments)
+            .WithOne(_ => _.Plaza)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/Thunders.TechTest.ApiService/Domain/Reports/Execution/IFileStorage.cs
+++ b/Thunders.TechTest.ApiService/Domain/Reports/Execution/IFileStorage.cs
@@ -1,0 +1,6 @@
+﻿namespace Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+public interface IFileStorage
+{
+    Task StoreAsync(string fileName, string folder, Stream file, Report report);
+}

--- a/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportDataCollector.cs
+++ b/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportDataCollector.cs
@@ -1,0 +1,6 @@
+﻿namespace Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+public interface IReportDataCollector<T>
+{
+    Task<T> CollectDataAsync(Report report, CancellationToken cancellationToken);
+}

--- a/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportExecutor.cs
+++ b/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportExecutor.cs
@@ -1,0 +1,7 @@
+﻿namespace Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+public interface IReportExecutor
+{
+    object? Data { get; }
+    Task<Stream> ExecuteReportGenerationAsync(Report report, CancellationToken cancellationToken);
+}

--- a/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportExecutorFactory.cs
+++ b/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportExecutorFactory.cs
@@ -1,0 +1,6 @@
+﻿namespace Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+public interface IReportExecutorFactory
+{
+    IReportExecutor CreateInstanceBy(ReportType type, ReportFormatType format);
+}

--- a/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportFileGenerator.cs
+++ b/Thunders.TechTest.ApiService/Domain/Reports/Execution/IReportFileGenerator.cs
@@ -1,0 +1,6 @@
+﻿namespace Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+public interface IReportFileGenerator<T>
+{
+    Stream GenerateFile(T data);
+}

--- a/Thunders.TechTest.ApiService/Domain/Reports/Report.cs
+++ b/Thunders.TechTest.ApiService/Domain/Reports/Report.cs
@@ -32,4 +32,7 @@ public class Report : IEntity
 	public string? PostbackUrl { get; set; }
 
     public ICollection<ReportParameter> Parameters { get; init; } = [];
+
+    public ReportParameter? GetParameterByName(string parameterName) =>
+        Parameters.FirstOrDefault(p => p.Name.Equals(parameterName, StringComparison.OrdinalIgnoreCase));
 }

--- a/Thunders.TechTest.ApiService/Domain/Tolls/TollPlaza.cs
+++ b/Thunders.TechTest.ApiService/Domain/Tolls/TollPlaza.cs
@@ -50,6 +50,11 @@ public class TollPlaza : IEntity
     /// </summary>
     public required TollConcessionaire Concessionaire { get; init; }
 
+    /// <summary>
+    /// Payments in plaza of toll.
+    /// </summary>
+    public ICollection<TollPayment> Payments { get; init; } = [];
+
     public static TollPlaza New(Guid id) =>
         new()
         {

--- a/Thunders.TechTest.ApiService/Messaging/Reports/GenerateReport/GenerateReportConsumer.cs
+++ b/Thunders.TechTest.ApiService/Messaging/Reports/GenerateReport/GenerateReportConsumer.cs
@@ -1,19 +1,27 @@
 ﻿using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 using Rebus.Handlers;
 using Thunders.TechTest.ApiService.Data;
 using Thunders.TechTest.ApiService.Domain.Reports;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
 
 namespace Thunders.TechTest.ApiService.Messaging.Reports.GenerateReport;
 
 public class GenerateReportConsumer(
     TollDbContext tollDbContext,
+    IFileStorage fileStorage,
+    IReportExecutorFactory executorFactory,
     ILogger<GenerateReportConsumer> logger)
     : IHandleMessages<GenerateReportMessage>
 {
     public async Task Handle(GenerateReportMessage message)
     {
         var timer = Stopwatch.StartNew();
-        var report = tollDbContext.Find<Report>(message.ReportId);
+        var report = await tollDbContext
+            .Set<Report>()
+            .Include(_ => _.Parameters)
+            .FirstOrDefaultAsync(r => r.Id == message.ReportId);
 
         if (report is null)
         {
@@ -21,31 +29,51 @@ public class GenerateReportConsumer(
             return;
         }
 
+        logger.LogInformation($"Report #{report.Id} started for type {report.Type} in format {report.FormatType}");
         report.Status = ReportStatusType.Started;
 
         await tollDbContext.SaveChangesAsync();
 
         try
         {
-            await GenerateReportAsync(report);
+            await GenerateReportAsync(report, default);
             report.Status = ReportStatusType.Generated;
+            logger.LogInformation($"Report #{report.Id} generated successfully for type {report.Type} in format {report.FormatType}");
         }
         catch (Exception ex)
         {
             report.Status = ReportStatusType.Error;
             report.ErrorMessage = ex.Message;
+            logger.LogError(ex, $"Report #{report.Id} had error for type {report.Type} in format {report.FormatType}");
         }
         finally
         {
             timer.Stop();
-            report.ElapsedExecution = timer.Elapsed;
-            report.FinishedAt = DateTime.UtcNow;
-            await tollDbContext.SaveChangesAsync();
         }
+
+        report.ElapsedExecution = timer.Elapsed;
+        report.FinishedAt = DateTime.UtcNow;
+
+        await tollDbContext.SaveChangesAsync();
+
+        logger.LogInformation($"Report #{report.Id} completed in {timer.Elapsed} for type {report.Type} in format {report.FormatType}");
     }
 
-    private Task GenerateReportAsync(Report report)
+    private async Task GenerateReportAsync(
+        Report report,
+        CancellationToken cancellationToken)
     {
-        return Task.CompletedTask;
+        var reportExecutor = executorFactory.CreateInstanceBy(report.Type, report.FormatType);
+
+        using var fileStream = await reportExecutor.ExecuteReportGenerationAsync(report, cancellationToken);
+
+        report.JsonResultData = JsonSerializer.Serialize(reportExecutor.Data);
+        report.BlobFile = fileStream is MemoryStream memo ? memo.GetBuffer() : null;
+
+        await fileStorage.StoreAsync(
+            report.FileName,
+            string.Empty,
+            fileStream,
+            report);
     }
 }

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthCsvGenerator.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthCsvGenerator.cs
@@ -1,0 +1,31 @@
+﻿using CsvHelper;
+using System.Globalization;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TopEarningTollPlazasPerMonth;
+
+public class TopEarningTollPlazasPerMonthCsvGenerator :
+    IReportFileGenerator<TopEarningTollPlazasPerMonthData>
+{
+    public Stream GenerateFile(TopEarningTollPlazasPerMonthData data)
+    {
+        var portugueseCulture = new CultureInfo("pt-BR");
+        var buffer = new MemoryStream();
+
+        var lines = data.Months.SelectMany(m => m.Plazas.Select(p => new
+        {
+            Month = m.GetMonthName(portugueseCulture),
+            p.TollPlazaName,
+            p.Total,
+        }));
+
+        using (var writer = new StreamWriter(buffer))
+        using (var csv = new CsvWriter(writer, portugueseCulture))
+        {
+            csv.WriteRecords(lines);
+            writer.Flush();
+        }
+
+        return buffer;
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthData.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthData.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TopEarningTollPlazasPerMonth;
+
+public record TopEarningTollPlazasPerMonthData
+{
+    public required ICollection<TopEarningMonthly> Months { get; init; }
+}
+
+public record TopEarningMonthly
+{
+    public int MonthNumber { get; init; }
+    public required ICollection<TopEarningPlaza> Plazas { get; init; }
+
+    public string GetMonthName(CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture, nameof(culture));
+
+        return culture.DateTimeFormat.GetMonthName(MonthNumber);
+    }
+}
+
+public record TopEarningPlaza
+{
+    public required string TollPlazaName { get; init; }
+    public decimal Total { get; init; }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthDataCollector.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthDataCollector.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Thunders.TechTest.ApiService.Data;
+using Thunders.TechTest.ApiService.Domain.Reports;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+using Thunders.TechTest.ApiService.Domain.Tolls;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TopEarningTollPlazasPerMonth;
+
+public class TopEarningTollPlazasPerMonthDataCollector(TollDbContext dbContext) :
+    IReportDataCollector<TopEarningTollPlazasPerMonthData>
+{
+    public int MaximumPlazasPerMonth { get; set; }
+
+    public async Task<TopEarningTollPlazasPerMonthData> CollectDataAsync(
+        Report report,
+        CancellationToken cancellationToken)
+    {
+        var maxPlazasPerMonth = MaximumPlazasPerMonth;
+        var maxPlazasPerMonthParameter = report.GetParameterByName("MAX_PLAZAS_PER_MONTH");
+        if (maxPlazasPerMonthParameter is not null && maxPlazasPerMonthParameter.ValueAsInt() <= MaximumPlazasPerMonth)
+        {
+            maxPlazasPerMonth = maxPlazasPerMonthParameter.ValueAsInt();
+        }
+
+        var ratedMonthly = await dbContext.Set<TollPayment>()
+            .GroupBy(p => p.PaidAt.Month)
+            .Select(g => new TopEarningMonthly
+            {
+                MonthNumber = g.Key,
+                Plazas = g.GroupBy(_ => _.Plaza.Id)
+                    .Select(g => new TopEarningPlaza
+                    {
+                        TollPlazaName = $"{g.First().Plaza.Concessionaire.CompanyName} {g.First().Plaza.City}",
+                        Total = g.Sum(s => s.Amount),
+                    })
+                    .OrderByDescending(o => o.Total)
+                    .Take(maxPlazasPerMonth)
+                    .ToArray(),
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return new()
+        {
+            Months = ratedMonthly,
+        };
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthPdfGenerator.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TopEarningTollPlazasPerMonth/TopEarningTollPlazasPerMonthPdfGenerator.cs
@@ -1,0 +1,12 @@
+﻿using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TopEarningTollPlazasPerMonth;
+
+public class TopEarningTollPlazasPerMonthPdfGenerator :
+    IReportFileGenerator<TopEarningTollPlazasPerMonthData>
+{
+    public Stream GenerateFile(TopEarningTollPlazasPerMonthData data)
+    {
+        return new MemoryStream();
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityCsvGenerator.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityCsvGenerator.cs
@@ -1,0 +1,30 @@
+﻿using CsvHelper;
+using System.Globalization;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TotalPerHourByCity;
+
+public class TotalPerHourByCityCsvGenerator :
+    IReportFileGenerator<TotalPerHourByCityData>
+{
+    public Stream GenerateFile(TotalPerHourByCityData data)
+    {
+        var buffer = new MemoryStream();
+
+        var lines = data.Cities.SelectMany(c => c.Hours.Select(h => new
+        {
+            c.CityName,
+            h.Hour,
+            h.Total,
+        }));
+
+        using (var writer = new StreamWriter(buffer))
+        using (var csv = new CsvWriter(writer, new CultureInfo("pt-BR")))
+        {
+            csv.WriteRecords(lines);
+            writer.Flush();
+        }
+
+        return buffer;
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityData.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityData.cs
@@ -1,0 +1,22 @@
+﻿using Thunders.TechTest.ApiService.Messaging.Reports.GenerateReport;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TotalPerHourByCity;
+
+public record TotalPerHourByCityData
+{
+    public required ICollection<CityData> Cities { get; init; }
+}
+
+public record CityData
+{
+    public required string CityName { get; init; }
+
+    public required ICollection<HourData> Hours { get; init; }
+}
+
+public record HourData
+{
+    public required int Hour { get; init; }
+
+    public required decimal Total { get; init; }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityDataCollector.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityDataCollector.cs
@@ -1,0 +1,38 @@
+﻿using Thunders.TechTest.ApiService.Data;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+using Thunders.TechTest.ApiService.Domain.Reports;
+using Thunders.TechTest.ApiService.Domain.Tolls;
+using Microsoft.EntityFrameworkCore;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TotalPerHourByCity;
+
+public class TotalPerHourByCityDataCollector(TollDbContext dbContext) :
+    IReportDataCollector<TotalPerHourByCityData>
+{
+    public async Task<TotalPerHourByCityData> CollectDataAsync(
+        Report report,
+        CancellationToken cancellationToken)
+    {
+        var cities = await dbContext.Set<TollPlaza>()
+            .GroupBy(p => p.Id)
+            .Select(g => new CityData
+            {
+                CityName = g.First().City,
+                Hours = g.SelectMany(t => t.Payments)
+                    .GroupBy(p => p.PaidAt.Hour)
+                    .Select(pg => new HourData
+                    {
+                        Hour = pg.Key,
+                        Total = pg.Sum(_ => _.Amount)
+                    })
+                    .OrderBy(r => r.Hour)
+                    .ToArray(),
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return new()
+        {
+            Cities = cities,
+        };
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityPdfGenerator.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/TotalPerHourByCity/TotalPerHourByCityPdfGenerator.cs
@@ -1,0 +1,12 @@
+﻿using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.TotalPerHourByCity;
+
+public class TotalPerHourByCityPdfGenerator :
+    IReportFileGenerator<TotalPerHourByCityData>
+{
+    public Stream GenerateFile(TotalPerHourByCityData data)
+    {
+        return new MemoryStream();
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaCsvGenerator.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaCsvGenerator.cs
@@ -1,0 +1,31 @@
+﻿using CsvHelper;
+using System.Globalization;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.VehicleClassificationByTollPlaza;
+
+public class VehicleClassificationByTollPlazaCsvGenerator :
+    IReportFileGenerator<VehicleClassificationByTollPlazaData>
+{
+    public Stream GenerateFile(VehicleClassificationByTollPlazaData data)
+    {
+        var portugueseCulture = new CultureInfo("pt-BR");
+        var buffer = new MemoryStream();
+
+        var lines = data.Plazas.SelectMany(p => p.Vehicles.Select(v => new
+        {
+            p.TollPlazaName,
+            v.VehicleName,
+            v.Quantity,
+        }));
+
+        using (var writer = new StreamWriter(buffer))
+        using (var csv = new CsvWriter(writer, portugueseCulture))
+        {
+            csv.WriteRecords(lines);
+            writer.Flush();
+        }
+
+        return buffer;
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaData.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaData.cs
@@ -1,0 +1,30 @@
+﻿using Thunders.TechTest.ApiService.Domain;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.VehicleClassificationByTollPlaza;
+
+public record VehicleClassificationByTollPlazaData
+{
+    public required ICollection<PlazaVehiclesData> Plazas { get; init; }
+}
+
+public record PlazaVehiclesData
+{
+    public required string TollPlazaName { get; init; }
+    public required ICollection<VehicleData> Vehicles { get; init; }
+}
+
+public record VehicleData
+{
+    public VehicleType Vehicle { get; init; }
+    public long Quantity { get; init; }
+
+    public string VehicleName =>
+        Vehicle switch
+        {
+            VehicleType.Car => "Carro",
+            VehicleType.Motorcycle => "Moto",
+            VehicleType.Truck => "Caminhão",
+
+            _ => throw new NotImplementedException(),
+        };
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaDataCollector.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaDataCollector.cs
@@ -1,0 +1,53 @@
+﻿using Thunders.TechTest.ApiService.Data;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+using Thunders.TechTest.ApiService.Domain.Reports;
+using Thunders.TechTest.ApiService.Domain.Tolls;
+using Microsoft.EntityFrameworkCore;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.VehicleClassificationByTollPlaza;
+
+public class VehicleClassificationByTollPlazaDataCollector(TollDbContext dbContext) :
+    IReportDataCollector<VehicleClassificationByTollPlazaData>
+{
+    public async Task<VehicleClassificationByTollPlazaData> CollectDataAsync(
+        Report report,
+        CancellationToken cancellationToken)
+    {
+        Guid[]? plazasIdsToFilter = null;
+        var maxPlazasPerMonthParameter = report.GetParameterByName("PLAZAS_IDS");
+        if (maxPlazasPerMonthParameter is not null)
+        {
+            plazasIdsToFilter = maxPlazasPerMonthParameter.Value.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(i => Guid.TryParse(i, out var result) ? result : Guid.Empty)
+                .Where(i => i != Guid.Empty)
+                .ToArray();
+        }
+
+        IQueryable<TollPayment> query = dbContext.Set<TollPayment>();
+
+        if (plazasIdsToFilter?.Length > 0)
+        {
+            query = query.Where(q => plazasIdsToFilter.Contains(q.Plaza.Id));
+        }
+
+        var plazas = await
+            query.GroupBy(p => p.Plaza.Id)
+            .Select(g => new PlazaVehiclesData
+            {
+                TollPlazaName = $"{g.First().Plaza.Concessionaire.CompanyName} {g.First().Plaza.City}",
+                Vehicles = g.GroupBy(_ => _.Vehicle)
+                    .Select(_ => new VehicleData
+                    {
+                        Vehicle = _.Key,
+                        Quantity = _.LongCount()
+                    })
+                    .ToArray(),
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return new()
+        {
+            Plazas = plazas,
+        };
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaPdfGenerator.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/Executions/VehicleClassificationByTollPlaza/VehicleClassificationByTollPlazaPdfGenerator.cs
@@ -1,0 +1,12 @@
+﻿using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+namespace Thunders.TechTest.ApiService.Services.Reports.Executions.VehicleClassificationByTollPlaza;
+
+public class VehicleClassificationByTollPlazaPdfGenerator :
+    IReportFileGenerator<VehicleClassificationByTollPlazaData>
+{
+    public Stream GenerateFile(VehicleClassificationByTollPlazaData data)
+    {
+        return new MemoryStream();
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/FileGeneratorExecutor.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/FileGeneratorExecutor.cs
@@ -1,0 +1,19 @@
+﻿using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+using Thunders.TechTest.ApiService.Domain.Reports;
+
+namespace Thunders.TechTest.ApiService.Services.Reports;
+
+public class FileGeneratorExecutor<T>(
+    IReportDataCollector<T> dataCollector,
+    IReportFileGenerator<T> fileGenerator) :
+    IReportExecutor
+{
+    public object? Data { get; private set; }
+
+    public async Task<Stream> ExecuteReportGenerationAsync(Report report, CancellationToken cancellationToken)
+    {
+        var data = await dataCollector.CollectDataAsync(report, cancellationToken);
+        Data = data;
+        return fileGenerator.GenerateFile(data);
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/LocalFileStorage.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/LocalFileStorage.cs
@@ -1,0 +1,13 @@
+﻿using Thunders.TechTest.ApiService.Domain.Reports;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+
+namespace Thunders.TechTest.ApiService.Services.Reports;
+
+public class LocalFileStorage : IFileStorage
+{
+    public Task StoreAsync(string fileName, string folder, Stream file, Report report)
+    {
+        var buffer = file is MemoryStream memo ? memo.GetBuffer() : null;
+        return File.WriteAllBytesAsync($"C:\\Users\\guigu\\Desktop\\teste\\{report.FileName}", buffer);
+    }
+}

--- a/Thunders.TechTest.ApiService/Services/Reports/ReportExecutorFactory.cs
+++ b/Thunders.TechTest.ApiService/Services/Reports/ReportExecutorFactory.cs
@@ -1,0 +1,82 @@
+﻿using Thunders.TechTest.ApiService.Data;
+using Thunders.TechTest.ApiService.Domain.Reports;
+using Thunders.TechTest.ApiService.Domain.Reports.Execution;
+using Thunders.TechTest.ApiService.Services.Reports.Executions.TopEarningTollPlazasPerMonth;
+using Thunders.TechTest.ApiService.Services.Reports.Executions.TotalPerHourByCity;
+using Thunders.TechTest.ApiService.Services.Reports.Executions.VehicleClassificationByTollPlaza;
+
+namespace Thunders.TechTest.ApiService.Services.Reports;
+
+public class ReportExecutorFactory(
+    TollDbContext dbContext,
+    IConfiguration configuration) :
+    IReportExecutorFactory
+{
+    public IReportExecutor CreateInstanceBy(ReportType type, ReportFormatType format)
+    {
+        return type switch
+        {
+            ReportType.TotalPerHourByCity =>
+                new FileGeneratorExecutor<TotalPerHourByCityData>(
+                    new TotalPerHourByCityDataCollector(dbContext),
+                    CreateGeneratorForTotalPerHourByCity(format)),
+
+            ReportType.TopEarningTollPlazasPerMonth =>
+                new FileGeneratorExecutor<TopEarningTollPlazasPerMonthData>(
+                    new TopEarningTollPlazasPerMonthDataCollector(dbContext)
+                    {
+                        MaximumPlazasPerMonth = Convert.ToInt32(configuration["Report:MaxPlazasPerMonth"]),
+                    },
+                    CreateGeneratorForTopEarningTollPlazasPerMonth(format)),
+
+            ReportType.VehicleClassificationByTollPlaza =>
+                new FileGeneratorExecutor<VehicleClassificationByTollPlazaData>(
+                    new VehicleClassificationByTollPlazaDataCollector(dbContext),
+                    CreateGeneratorForVehicleClassificationByTollPlaza(format)),
+
+            _ => throw new InvalidOperationException($"Not available file generator for type '{type}' in this moment."),
+        };
+    }
+
+    private IReportFileGenerator<TotalPerHourByCityData> CreateGeneratorForTotalPerHourByCity(ReportFormatType format)
+    {
+        return format switch
+        {
+            ReportFormatType.Csv =>
+                new TotalPerHourByCityCsvGenerator(),
+
+            ReportFormatType.Pdf =>
+                new TotalPerHourByCityPdfGenerator(),
+
+            _ => throw new InvalidOperationException($"Not available file generator in format '{format}' for report TotalPerHourByCity.")
+        };
+    }
+
+    private IReportFileGenerator<TopEarningTollPlazasPerMonthData> CreateGeneratorForTopEarningTollPlazasPerMonth(ReportFormatType format)
+    {
+        return format switch
+        {
+            ReportFormatType.Csv =>
+                new TopEarningTollPlazasPerMonthCsvGenerator(),
+
+            ReportFormatType.Pdf =>
+                new TopEarningTollPlazasPerMonthPdfGenerator(),
+
+            _ => throw new InvalidOperationException($"Not available file generator in format '{format}' for report TopEarningTollPlazasPerMonth.")
+        };
+    }
+
+    private IReportFileGenerator<VehicleClassificationByTollPlazaData> CreateGeneratorForVehicleClassificationByTollPlaza(ReportFormatType format)
+    {
+        return format switch
+        {
+            ReportFormatType.Csv =>
+                new VehicleClassificationByTollPlazaCsvGenerator(),
+
+            ReportFormatType.Pdf =>
+                new VehicleClassificationByTollPlazaPdfGenerator(),
+
+            _ => throw new InvalidOperationException($"Not available file generator in format '{format}' for report VehicleClassificationByTollPlaza.")
+        };
+    }
+}

--- a/Thunders.TechTest.ApiService/Thunders.TechTest.ApiService.csproj
+++ b/Thunders.TechTest.ApiService/Thunders.TechTest.ApiService.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>

--- a/Thunders.TechTest.ApiService/appsettings.json
+++ b/Thunders.TechTest.ApiService/appsettings.json
@@ -4,12 +4,16 @@
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.AspNetCore": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.EntityFrameworkCore": "Information"
     }
   },
   "AllowedHosts": "*",
   "Features": {
     "UseMessageBroker": true,
     "UseEntityFramework": true
+  },
+  "Report": {
+    "MaxPlazasPerMonth": 5
   }
 }


### PR DESCRIPTION
Implementado os 3 relatórios do enum `ReportType`, segue:

* `TotalPerHourByCity`: Valor total por hora por cidade.
* `TopEarningTollPlazasPerMonth`: As praças que mais faturaram por mês (a quantidade a ser processada deve ser configurável).
* `VehicleClassificationByTollPlaza`: Quantos tipos de veículos passaram em uma determinada praça.

Para agendar a execução, chamar a api `POST /api/report` com o seguinte body:
```
{
  "FileName": "report_18.csv",
  "Type": "VehicleClassificationByTollPlaza",
  "FormatType": "CSV",
  "PostbackUrl": null
}
```

Alguns relatórios podem ter parâmetros opcionais ou não para executar utilizar o campo `Parameters`, como exemplo abaixo:

```
{
  "FileName": "report_18.csv",
  "Type": "VehicleClassificationByTollPlaza",
  "FormatType": "CSV",
  "PostbackUrl": null,
  "Parameters": [ /// ----->> esse aqui!
    {
      "Name": "PLAZAS_IDS",
      "Value": "7a5570d8-4a7e-4a51-bfae-08dd921885eb,4592c617-14f2-454c-bfaf-08dd921885eb"
    }
  ]
}
```

Segue a relação de parâmetros por relatório:

| Tipo relatório | Nome parâmetro | Tipo valor | Observação |
|----------------|---------------------|------------|--------------|
| TopEarningTollPlazasPerMonth | MAX_PLAZAS_PER_MONTH | int | Indicar a quantidade máxima de praças de pedágio por mês. Caso a configuração supere a parametrização máxima definida no sistema, será adotada o que estiver no sistema. |
| VehicleClassificationByTollPlaza | PLAZAS_IDS | guid[] | Lista dos ids de praças para filtrar. |